### PR TITLE
Added OFI/UCX options and comment about MV2_ENABLE_AFFINITY

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,16 +10,21 @@ export CC=$(basename "$CC")
 export CXX=$(basename "$CXX")
 export FC=$(basename "$FC")
 
-build_with_rdma=""
-if [[ "$target_platform" == linux-* ]]; then
-    echo "Build with RDMA support"
-    build_with_rdma="--with-rdma=$PREFIX --enable-rdma-cm "
+# Support for ch4:ucx or ch4:ofi devices
+build_with_device=""
+if [ "$device" == "ucx" ]; then
+    echo "Build with UCX support"
+    build_with_device=" --with-device=ch4:ucx --with-ucx=$PREFIX "
+else
+    echo "Build with OFI support"
+    build_with_device=" --with-device=ch4:ofi "
 fi
 
 ./configure --prefix=$PREFIX \
-            --with-device=ch4:ofi \
+            $build_with_device \
             --with-hwloc-prefix=$PREFIX \
-            $build_with_rdma \
+            --with-rdma=$PREFIX \
+            --enable-rdma-cm \
             --enable-fortran=all \
             --enable-romio \
             --enable-nemesis-shm-collectives \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+device:
+  - ucx
+  - ofi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,15 +43,15 @@ about:
   license_family: BSD
   license_file: COPYRIGHT
   summary: MVAPICH, a high-performance MPI library by The Ohio State University.
-  description: 
-    MVAPICH2 is a high-performance implementation of the MPI (Message Passing Interface) standard. 
+  description: |
+    MVAPICH2 is a high-performance implementation of the MPI (Message Passing Interface) standard.
     It provides enhancements including optimization for different networking technologies.
+    
     ### Important Configuration
-    The default value for `MV2_ENABLE_AFFINITY` is typically `1` (enabled). This setting binds MPI processes 
+    The default value for `MV2_ENABLE_AFFINITY` is typically `1` (enabled). This setting binds MPI processes
     to specific CPU cores to improve performance due to cache locality and reduced context switching.
-    In some environments, particularly those using the Slurm job scheduler, this may degrade performances 
+    In some environments, particularly those using the Slurm job scheduler, this may degrade performances
     or lead to unexpected behavior, and hence it may be beneficial to set `MV2_ENABLE_AFFINITY=0`.
-
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "3.0" %}
+{% set device_variant = device if device else "default" %}
 
 package:
   name: mvapich
@@ -10,6 +11,7 @@ source:
 
 build:
   number: 0
+  string: "h{{ PKG_HASH }}_{{ device_variant }}"
   skip: true  # [win or osx]
   run_exports:
     - {{ pin_subpackage('mvapich', max_pin='x.y') }}
@@ -25,6 +27,9 @@ requirements:
   host:
     - libhwloc
     - rdma-core  # [linux]
+    {% if device == "ucx" %}
+    - ucx
+    {% endif %}
   run:
     - mpi 1.0.* mvapich
 
@@ -38,6 +43,15 @@ about:
   license_family: BSD
   license_file: COPYRIGHT
   summary: MVAPICH, a high-performance MPI library by The Ohio State University.
+  description: 
+    MVAPICH2 is a high-performance implementation of the MPI (Message Passing Interface) standard. 
+    It provides enhancements including optimization for different networking technologies.
+    ### Important Configuration
+    The default value for `MV2_ENABLE_AFFINITY` is typically `1` (enabled). This setting binds MPI processes 
+    to specific CPU cores to improve performance due to cache locality and reduced context switching.
+    In some environments, particularly those using the Slurm job scheduler, this may degrade performances 
+    or lead to unexpected behavior, and hence it may be beneficial to set `MV2_ENABLE_AFFINITY=0`.
+
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
