### PR TITLE
Remove osx arm64

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,28 +8,28 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_deviceofi:
-        CONFIG: linux_64_deviceofi
+      linux_64_netmodofi:
+        CONFIG: linux_64_netmodofi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_deviceucx:
-        CONFIG: linux_64_deviceucx
+      linux_64_netmoducx:
+        CONFIG: linux_64_netmoducx
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_deviceofi:
-        CONFIG: linux_aarch64_deviceofi
+      linux_aarch64_netmodofi:
+        CONFIG: linux_aarch64_netmodofi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_deviceucx:
-        CONFIG: linux_aarch64_deviceucx
+      linux_aarch64_netmoducx:
+        CONFIG: linux_aarch64_netmoducx
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_deviceofi:
-        CONFIG: linux_ppc64le_deviceofi
+      linux_ppc64le_netmodofi:
+        CONFIG: linux_ppc64le_netmodofi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_deviceucx:
-        CONFIG: linux_ppc64le_deviceucx
+      linux_ppc64le_netmoducx:
+        CONFIG: linux_ppc64le_netmoducx
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_netmodofi.yaml
+++ b/.ci_support/linux_64_netmodofi.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -20,8 +16,6 @@ cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '13'
-device:
-- ofi
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
@@ -30,10 +24,10 @@ fortran_compiler_version:
 - '13'
 libhwloc:
 - 2.11.2
-rdma_core:
-- '53'
+netmod:
+- ofi
 target_platform:
-- linux-aarch64
+- linux-64
 ucx:
 - '1.17'
 zip_keys:

--- a/.ci_support/linux_64_netmoducx.yaml
+++ b/.ci_support/linux_64_netmoducx.yaml
@@ -16,8 +16,6 @@ cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '13'
-device:
-- ucx
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
@@ -26,10 +24,10 @@ fortran_compiler_version:
 - '13'
 libhwloc:
 - 2.11.2
-rdma_core:
-- '53'
+netmod:
+- ucx
 target_platform:
-- linux-ppc64le
+- linux-64
 ucx:
 - '1.17'
 zip_keys:

--- a/.ci_support/linux_aarch64_netmodofi.yaml
+++ b/.ci_support/linux_aarch64_netmodofi.yaml
@@ -20,8 +20,6 @@ cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '13'
-device:
-- ucx
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
@@ -30,8 +28,8 @@ fortran_compiler_version:
 - '13'
 libhwloc:
 - 2.11.2
-rdma_core:
-- '53'
+netmod:
+- ofi
 target_platform:
 - linux-aarch64
 ucx:

--- a/.ci_support/linux_aarch64_netmoducx.yaml
+++ b/.ci_support/linux_aarch64_netmoducx.yaml
@@ -1,3 +1,5 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -6,6 +8,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -16,8 +20,6 @@ cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '13'
-device:
-- ucx
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
@@ -26,10 +28,10 @@ fortran_compiler_version:
 - '13'
 libhwloc:
 - 2.11.2
-rdma_core:
-- '53'
+netmod:
+- ucx
 target_platform:
-- linux-64
+- linux-aarch64
 ucx:
 - '1.17'
 zip_keys:

--- a/.ci_support/linux_ppc64le_netmodofi.yaml
+++ b/.ci_support/linux_ppc64le_netmodofi.yaml
@@ -16,8 +16,6 @@ cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '13'
-device:
-- ofi
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
@@ -26,10 +24,10 @@ fortran_compiler_version:
 - '13'
 libhwloc:
 - 2.11.2
-rdma_core:
-- '53'
+netmod:
+- ofi
 target_platform:
-- linux-64
+- linux-ppc64le
 ucx:
 - '1.17'
 zip_keys:

--- a/.ci_support/linux_ppc64le_netmoducx.yaml
+++ b/.ci_support/linux_ppc64le_netmoducx.yaml
@@ -16,8 +16,6 @@ cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '13'
-device:
-- ofi
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
@@ -26,8 +24,8 @@ fortran_compiler_version:
 - '13'
 libhwloc:
 - 2.11.2
-rdma_core:
-- '53'
+netmod:
+- ucx
 target_platform:
 - linux-ppc64le
 ucx:

--- a/README.md
+++ b/README.md
@@ -15,16 +15,20 @@ It provides enhancements including optimization for different networking technol
 
 The default value for `MV2_ENABLE_AFFINITY` is typically `1` (enabled). This setting binds MPI processes
 to specific CPU cores to improve performance due to cache locality and reduced context switching.
-In some environments, particularly those using the Slurm job scheduler, this may degrade performances
+In some environments, particularly those using the Slurm job scheduler, this may degrade performance
 or lead to unexpected behavior, and hence it may be beneficial to set `MV2_ENABLE_AFFINITY=0`.
 
 
-MVAPICH supports two high-level network APIs, namely OFI and UCX: to select the OFI version use
-`conda install conda-forge::mvapich=*=*_ofi`, and for the UCX version `conda install conda-forge::mvapich=*=*_ucx`.
+MVAPICH supports two high-level network modules (netmods), namely OFI and UCX:
+- For the OFI netmod, use: `conda install conda-forge::mvapich=*=*_ofi`
+- For the UCX netmod, use: `conda install conda-forge::mvapich=*=*_ucx`
+
+These commands will install the MVAPICH package configured with the desired netmod.
 
 
-Note that the actual GNU compilers (i.e., `gcc_linux-64`, `gfortran_linux-64` and `gxx_linux-64`) have to
-be added manually since they are not automatically installed in the Conda environment as dependencies.
+Note that the actual GNU compilers (i.e., `gcc_linux-64`, `gfortran_linux-64` and `gxx_linux-64` for `linux-64`, or
+their equivalent for other platforms) have to be added manually since they are not automatically installed in the Conda
+environment as dependencies.
 
 
 Current build status
@@ -45,45 +49,45 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_deviceofi</td>
+              <td>linux_64_netmodofi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=23590&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_deviceofi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_netmodofi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_deviceucx</td>
+              <td>linux_64_netmoducx</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=23590&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_deviceucx" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_netmoducx" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_deviceofi</td>
+              <td>linux_aarch64_netmodofi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=23590&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_deviceofi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_netmodofi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_deviceucx</td>
+              <td>linux_aarch64_netmoducx</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=23590&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_deviceucx" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_netmoducx" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_deviceofi</td>
+              <td>linux_ppc64le_netmodofi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=23590&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_deviceofi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_netmodofi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_deviceucx</td>
+              <td>linux_ppc64le_netmoducx</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=23590&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_deviceucx" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mvapich-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_netmoducx" alt="variant">
                 </a>
               </td>
             </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -8,4 +8,3 @@ conda_forge_output_validation: true
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64
-  osx_arm64: osx_64

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,18 +31,18 @@ if [[ $CONDA_BUILD_CROSS_COMPILATION == 1 ]]; then
   fi
 fi
 
-# Support for ch4:ucx or ch4:ofi devices
-build_with_device=""
-if [ "$device" == "ucx" ]; then
+# Set netmod configuration
+build_with_netmod=""
+if [ "$netmod" == "ucx" ]; then
   echo "Build with UCX support"
-  build_with_device=" --with-device=ch4:ucx --with-ucx=$PREFIX "
-else
+  build_with_netmod=" --with-device=ch4:ucx --with-ucx=$PREFIX "
+else  [[ "$netmod" == "ofi" ]]; then
   echo "Build with OFI support"
-  build_with_device=" --with-device=ch4:ofi "
+  build_with_netmod=" --with-device=ch4:ofi "
 fi
 
 ./configure --prefix=$PREFIX \
-            $build_with_device \
+            $build_with_netmod \
             --with-hwloc-prefix=$PREFIX \
             --with-rdma=$PREFIX \
             --enable-rdma-cm \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -36,7 +36,7 @@ build_with_netmod=""
 if [ "$netmod" == "ucx" ]; then
   echo "Build with UCX support"
   build_with_netmod=" --with-device=ch4:ucx --with-ucx=$PREFIX "
-else  [[ "$netmod" == "ofi" ]]; then
+else
   echo "Build with OFI support"
   build_with_netmod=" --with-device=ch4:ofi "
 fi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
-device:
+netmod:
   - ucx
   - ofi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.0" %}
-{% set device_variant = device if device else "default" %}
+{% set netmod_variant = netmod if netmod else "default" %}
 
 package:
   name: mvapich
@@ -11,9 +11,8 @@ source:
 
 build:
   number: 1
-  string: "h{{ PKG_HASH }}_{{ device_variant }}"
+  string: "h{{ PKG_HASH }}_{{ netmod_variant }}"
   skip: true  # [win or osx]
-  skip: false  # [arm64]
   run_exports:
     - {{ pin_subpackage('mvapich', max_pin='x.y') }}
 
@@ -27,7 +26,7 @@ requirements:
     - make
   host:
     - libhwloc
-    {% if device == "ucx" %}
+    {% if netmod == "ucx" %}
     - ucx >=1.12.0
     {% endif %}
   run:
@@ -53,20 +52,23 @@ about:
   description: |
     MVAPICH is a high-performance implementation of the MPI (Message Passing Interface) standard.
     It provides enhancements including optimization for different networking technologies.
-    
+
     ### Important Configuration
     The default value for `MV2_ENABLE_AFFINITY` is typically `1` (enabled). This setting binds MPI processes
     to specific CPU cores to improve performance due to cache locality and reduced context switching.
-    In some environments, particularly those using the Slurm job scheduler, this may degrade performances
+    In some environments, particularly those using the Slurm job scheduler, this may degrade performance
     or lead to unexpected behavior, and hence it may be beneficial to set `MV2_ENABLE_AFFINITY=0`.
 
-    ### OFI or UCX version
-    MVAPICH supports two high-level network APIs, namely OFI and UCX: to select the OFI version use 
-    `conda install conda-forge::mvapich=*=*_ofi`, and for the UCX version `conda install conda-forge::mvapich=*=*_ucx`.
+    ### Selecting Netmods: OFI or UCX
+    MVAPICH supports two high-level network modules (netmods), namely OFI and UCX:
+    - For the OFI netmod, use: `conda install conda-forge::mvapich=*=*_ofi`
+    - For the UCX netmod, use: `conda install conda-forge::mvapich=*=*_ucx`
 
-    ### About the compilers
+    These commands will install the MVAPICH package configured with the desired netmod.
+
+    ### About the Compilers
     Note that the actual GNU compilers (i.e., `gcc_linux-64`, `gfortran_linux-64` and `gxx_linux-64` for `linux-64`, or
-    their equivalent for other plateforms) have to be added manually since they are not automatically installed in the Conda 
+    their equivalent for other platforms) have to be added manually since they are not automatically installed in the Conda
     environment as dependencies.
     
 extra:


### PR DESCRIPTION
### Description
This pull request updates the build configuration files to:

- Use `netmod` for specifying network modules (OFI and UCX).
- Remove support for macOS (`osx-arm64`) for now.