### PR TITLE
need build number in build string

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "3.0" %}
+{% set build = 2 %}
 {% set netmod_variant = netmod if netmod else "default" %}
 
 package:
@@ -10,8 +11,8 @@ source:
   sha256: ee076c4e672d18d6bf8dd2250e4a91fa96aac1db2c788e4572b5513d86936efb
 
 build:
-  number: 1
-  string: "h{{ PKG_HASH }}_{{ netmod_variant }}"
+  number: {{ build }}
+  string: "{{ netmod_variant }}_h{{ PKG_HASH }}_{{ build }}"
   skip: true  # [win or osx]
   run_exports:
     - {{ pin_subpackage('mvapich', max_pin='x.y') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,8 +62,8 @@ about:
 
     ### Selecting Netmods: OFI or UCX
     MVAPICH supports two high-level network modules (netmods), namely OFI and UCX:
-    - For the OFI netmod, use: `conda install conda-forge::mvapich=*=*_ofi`
-    - For the UCX netmod, use: `conda install conda-forge::mvapich=*=*_ucx`
+    - For the OFI netmod, use: `conda install conda-forge::mvapich=*=ofi_*`
+    - For the UCX netmod, use: `conda install conda-forge::mvapich=*=ucx_*`
 
     These commands will install the MVAPICH package configured with the desired netmod.
 


### PR DESCRIPTION
otherwise new builds might not be uploaded because of a filename collision, since the dependency hash doesn't always change from one build to the next.

since build number goes on the end by convention (not _technically_ required), I moved the netmod variant to the front so `*ucx` becomes `ucx*` and it's not in the middle, which would need `*ucx*`.

If mvapich adds an `external_` variant as well like we have for other mpi providers, selecting on build strings is going to get tricky, and we'll probably want to use metapackages or something for selection, as conda actually doesn't support arbitrary overlapping globs on build strings. Build string prefixes work well enough as long as there's _exactly one_ variant axis to select on. As soon as there's more than one, it stops being sufficient.