### PR TITLE
Fix loose netmod_version for UCX

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,13 +32,13 @@ requirements:
     {% if netmod_variant == "ofi" and netmod_version %}
     - libfabric {{ netmod_version }}
     {% elif netmod_variant == "ucx" %}
-    - ucx >=1.12.0
+    - ucx {{ netmod_version }}
     {% endif %}
   run:
     {% if netmod_variant == "ofi" and netmod_version %}
     - libfabric {{ netmod_version }}
     {% elif netmod_variant == "ucx" %}
-    - ucx >=1.12.0
+    - ucx {{ netmod_version }}
     {% endif %}
     - rdma-core
     - mpi 1.0.* mvapich


### PR DESCRIPTION
This PR fixes the looser constraint for UCX in `meta.yaml` to make it match exactly what is defined in the `conda_build_config.yaml`

-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
