### PR TITLE
Build with support for both ucx and ofi

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,12 +8,6 @@ export CC=$(basename "$CC")
 export CXX=$(basename "$CXX")
 export FC=$(basename "$FC")
 
-build_with_rdma=""
-if [[ "$target_platform" == linux-* ]]; then
-  echo "Build with RDMA support"
-  build_with_rdma="--with-rdma=$PREFIX --enable-rdma-cm "
-fi
-
 if [[ $CONDA_BUILD_CROSS_COMPILATION == 1 ]]; then
   if [[ "$target_platform" == "linux-aarch64" || "$target_platform" == "linux-ppc64le" ]]; then
     export CROSS_F77_SIZEOF_INTEGER=4
@@ -29,35 +23,6 @@ if [[ $CONDA_BUILD_CROSS_COMPILATION == 1 ]]; then
   fi
 fi
 
-# Set netmod configuration
-build_with_netmod=""
-IFS='-' read -ra netmod_parts <<< "$netmod"
-netmod_variant="${netmod_parts[0]}"
-netmod_version="${netmod_parts[1]}"
-
-if [ "$netmod_variant" == "ucx" ]; then
-  echo "Build with UCX support"
-  build_with_netmod=" --with-device=ch4:ucx --with-ucx=$PREFIX "
-else
-  echo "Build with external OFI support"
-  build_with_netmod=" --with-device=ch4:ofi --with-ofi=$PREFIX "
-fi
-
-# Avoid recording flags in compilers, adapted from MPICH
-# Save the current flags
-export SAVED_CPPFLAGS=$CPPFLAGS
-unset CPPFLAGS
-export SAVED_CFLAGS=$CFLAGS
-unset CFLAGS
-export SAVED_CXXFLAGS=$CXXFLAGS
-unset CXXFLAGS
-export SAVED_LDFLAGS=$LDFLAGS
-unset LDFLAGS
-export SAVED_FFLAGS=$FFLAGS
-unset FFLAGS
-export SAVED_FCFLAGS=$FCFLAGS
-unset FCFLAGS
-
 # Set minimal necessary flags for this build process
 export CPPFLAGS="-I$PREFIX/include"
 export CFLAGS="-I$PREFIX/include"
@@ -69,25 +34,17 @@ export LDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 export LIBRARY_PATH="$PREFIX/lib"
 
 ./configure --prefix=$PREFIX \
-            $build_with_netmod \
-            --with-hwloc-prefix=$PREFIX \
-            --with-rdma=$PREFIX \
-            --enable-rdma-cm \
+	    --with-device=ch4:ucx,ofi \
+	    --with-ucx=$PREFIX \
+            --with-libfabric=$PREFIX \
+            --with-libfabric-include=$PREFIX/include \
+            --with-libfabric-lib=$PREFIX/lib \
             --enable-fortran=all \
             --enable-romio \
             --enable-nemesis-shm-collectives \
-            --disable-cuda \
             --disable-dependency-tracking \
             --with-sysroot \
             --enable-static=no
 
 make -j"${CPU_COUNT}"
 make install
-
-# Restore the saved flags after configuration
-export CPPFLAGS=$SAVED_CPPFLAGS
-export CFLAGS=$SAVED_CFLAGS
-export CXXFLAGS=$SAVED_CXXFLAGS
-export LDFLAGS=$SAVED_LDFLAGS
-export FFLAGS=$SAVED_FFLAGS
-export FCFLAGS=$SAVED_FCFLAGS

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,5 @@
 {% set version = "4.0" %}
-{% set build = 2 %}
-{% set netmod = netmod or 'default' %}
-{% set netmod_variant = netmod.split('-')[0] %}
-{% set netmod_version = netmod.split('-')[1] if '-' in netmod else '' %}
+{% set build = 4 %}
 
 package:
   name: mvapich
@@ -16,7 +13,7 @@ source:
 
 build:
   number: {{ build }}
-  string: {{ netmod_variant }}_{{ netmod_version|replace('-','_') }}_h{{ PKG_HASH }}_{{ build }}
+  string: h{{ PKG_HASH }}_{{ build }}
   skip: true  # [win or osx]
   run_exports:
     - {{ pin_subpackage('mvapich', max_pin='x.y') }}
@@ -31,19 +28,12 @@ requirements:
     - make
   host:
     - libhwloc
-    {% if netmod_variant == "ofi" and netmod_version %}
-    - libfabric {{ netmod_version }}
-    {% elif netmod_variant == "ucx" %}
-    - ucx {{ netmod_version }}
-    {% endif %}
+    - libfabric-devel <2.0
+    - ucx
   run:
-    {% if netmod_variant == "ofi" and netmod_version %}
-    - libfabric {{ netmod_version }}
-    {% elif netmod_variant == "ucx" %}
-    - ucx {{ netmod_version }}
-    {% endif %}
-    - rdma-core
+    - libnl
     - mpi 1.0.* mvapich
+    - rdma-core
 
 test:
   requires:
@@ -63,23 +53,11 @@ about:
   license_file: COPYRIGHT
   summary: MVAPICH, a high-performance MPI library by The Ohio State University.
   description: |
-    MVAPICH is a high-performance implementation of the MPI (Message Passing Interface) standard.
-    It provides enhancements including optimization for different networking technologies.
+    MVAPICH is a high-performance implementation of the MPI (Message Passing Interface) standard 
+    with support for **both** Unified Communication X (UCX) and Open Fabric Interfaces (OFI).
 
-    ### Important Configuration
-    The default value for `MV2_ENABLE_AFFINITY` is typically `1` (enabled). This setting binds MPI processes
-    to specific CPU cores to improve performance due to cache locality and reduced context switching.
-    In some environments, particularly those using the Slurm job scheduler, this may degrade performance
-    or lead to unexpected behavior, and hence it may be beneficial to set `MV2_ENABLE_AFFINITY=0`.
-
-    ### Selecting Netmods: OFI (external) or UCX
-    MVAPICH supports two high-level network modules (netmods), namely UCX and OFI:
-    for the UCX netmod use `conda install conda-forge::mvapich=*=ucx*`, and
-    for the OFI netmod `conda install conda-forge::mvapich=*=ofi*`. 
-    As an *experiment* it is also possible to select a particular version of LibFabric or UCX, 
-    for instance 1.15.2 with `conda install conda-forge::mvapich=*=ofi_1.15.2*`.
-
-    These commands will install the MVAPICH package configured with the desired netmod.
+    In case the actual *netmod* is not correctly recognized at run time, activate it using either
+    `MPICH_CH4_NETMOD=ucx` or `MPICH_CH4_NETMOD=ofi`.
 
     ### About the Compilers
     Note that the actual GNU compilers (i.e., `gcc_linux-64`, `gfortran_linux-64` and `gxx_linux-64` for `linux-64`, or


### PR DESCRIPTION
This PR builds a single MVAPICH-4.0 for both Unified Communication X (UCX) and the standard Open Fabric Interfaces (OFI) framework, instead of two separate ucx and ofi variants.

@conda-forge-admin, please rerender


Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
